### PR TITLE
Add nutanix-specific terraform variables

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 	awsprovider "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1"
 
+	nutanixprovider "github.com/nutanix-cloud-native/machine-api-provider-nutanix/pkg/apis/nutanixprovider/v1beta1"
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/installer/pkg/asset"
@@ -42,6 +43,7 @@ import (
 	gcptfvars "github.com/openshift/installer/pkg/tfvars/gcp"
 	ibmcloudtfvars "github.com/openshift/installer/pkg/tfvars/ibmcloud"
 	libvirttfvars "github.com/openshift/installer/pkg/tfvars/libvirt"
+	nutanixtfvars "github.com/openshift/installer/pkg/tfvars/nutanix"
 	openstacktfvars "github.com/openshift/installer/pkg/tfvars/openstack"
 	ovirttfvars "github.com/openshift/installer/pkg/tfvars/ovirt"
 	vspheretfvars "github.com/openshift/installer/pkg/tfvars/vsphere"
@@ -54,6 +56,7 @@ import (
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	"github.com/openshift/installer/pkg/types/none"
+	"github.com/openshift/installer/pkg/types/nutanix"
 	"github.com/openshift/installer/pkg/types/openstack"
 	"github.com/openshift/installer/pkg/types/ovirt"
 	"github.com/openshift/installer/pkg/types/vsphere"
@@ -770,6 +773,39 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		t.FileList = append(t.FileList, &asset.File{
 			Filename: TfPlatformVarsFileName,
+			Data:     data,
+		})
+	case nutanix.Name:
+		if rhcosImage == nil {
+			return errors.New("Unable to retrieve rhcos image")
+		}
+		controlPlanes, err := mastersAsset.Machines()
+		if err != nil {
+			return errors.Wrapf(err, "error getting control plane machines")
+		}
+		controlPlaneConfigs := make([]*nutanixprovider.NutanixMachineProviderConfig, len(controlPlanes))
+		for i, c := range controlPlanes {
+			controlPlaneConfigs[i] = c.Spec.ProviderSpec.Value.Object.(*nutanixprovider.NutanixMachineProviderConfig)
+		}
+
+		data, err = nutanixtfvars.TFVars(
+			nutanixtfvars.TFVarsSources{
+				PrismCentral:          installConfig.Config.Nutanix.PrismCentral,
+				Insecure:              installConfig.Config.Nutanix.Insecure,
+				Port:                  installConfig.Config.Nutanix.Port,
+				Username:              installConfig.Config.Nutanix.Username,
+				Password:              installConfig.Config.Nutanix.Password,
+				ImageURL:              string(*rhcosImage),
+				BootstrapIgnitionData: bootstrapIgn,
+				ClusterID:             clusterID.InfraID,
+				ControlPlaneConfigs:   controlPlaneConfigs,
+			},
+		)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
+		}
+		t.FileList = append(t.FileList, &asset.File{
+			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
 			Data:     data,
 		})
 	default:

--- a/pkg/tfvars/nutanix/OWNERS
+++ b/pkg/tfvars/nutanix/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - nutanix-approvers
+reviewers:
+  - nutanix-reviewers

--- a/pkg/tfvars/nutanix/nutanix.go
+++ b/pkg/tfvars/nutanix/nutanix.go
@@ -1,0 +1,70 @@
+package nutanix
+
+import (
+	"encoding/json"
+
+	nutanixapis "github.com/nutanix-cloud-native/machine-api-provider-nutanix/pkg/apis/nutanixprovider/v1beta1"
+	"github.com/openshift/installer/pkg/tfvars/internal/cache"
+	nutanixtypes "github.com/openshift/installer/pkg/types/nutanix"
+	"github.com/pkg/errors"
+)
+
+type config struct {
+	PrismCentral           string `json:"prism_central"`
+	Port                   string `json:"port"`
+	Username               string `json:"username"`
+	Password               string `json:"password"`
+	MemoryMiB              int64  `json:"nutanix_control_plane_memory_mib"`
+	DiskSizeMib            int64  `json:"nutanix_control_plane_disk_mib"`
+	NumCPUs                int64  `json:"nutanix_control_plane_num_cpus"`
+	NumCoresPerSocket      int64  `json:"nutanix_control_plane_cores_per_socket"`
+	PrismElementUUID       string `json:"nutanix_prism_element_uuid"`
+	Insecure               bool   `json:"insecure"`
+	SubnetUUID             string `json:"nutanix_subnet_uuid"`
+	Image                  string `json:"nutanix_image"`
+	ImageFilePath          string `json:"nutanix_image_filepath"`
+	BootstrapIgnitionImage string `json:"nutanix_bootstrap_ignition_image"`
+}
+
+// TFVarsSources contains the parameters to be converted into Terraform variables
+type TFVarsSources struct {
+	PrismCentral          string
+	Port                  string
+	Username              string
+	Password              string
+	ImageURL              string
+	Insecure              bool
+	BootstrapIgnitionData string
+	ClusterID             string
+	ControlPlaneConfigs   []*nutanixapis.NutanixMachineProviderConfig
+}
+
+//TFVars generate Nutanix-specific Terraform variables
+func TFVars(sources TFVarsSources) ([]byte, error) {
+	cachedImage, err := cache.DownloadImageFile(sources.ImageURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to use cached nutanix image")
+	}
+	bootstrapIgnitionImage, err := nutanixtypes.CreateBootstrapISO(sources.ClusterID, sources.BootstrapIgnitionData)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create bootstrap ignition iso")
+	}
+	controlPlaneConfig := sources.ControlPlaneConfigs[0]
+	cfg := &config{
+		Port:                   sources.Port,
+		Insecure:               sources.Insecure,
+		PrismCentral:           sources.PrismCentral,
+		Username:               sources.Username,
+		Password:               sources.Password,
+		MemoryMiB:              controlPlaneConfig.MemorySizeMib,
+		DiskSizeMib:            controlPlaneConfig.DiskSizeMib,
+		NumCPUs:                controlPlaneConfig.NumSockets,
+		NumCoresPerSocket:      controlPlaneConfig.NumVcpusPerSocket,
+		PrismElementUUID:       controlPlaneConfig.ClusterReferenceUUID,
+		SubnetUUID:             controlPlaneConfig.SubnetUUID,
+		Image:                  controlPlaneConfig.ImageName,
+		ImageFilePath:          cachedImage,
+		BootstrapIgnitionImage: bootstrapIgnitionImage,
+	}
+	return json.MarshalIndent(cfg, "", "  ")
+}

--- a/pkg/types/nutanix/helpers.go
+++ b/pkg/types/nutanix/helpers.go
@@ -31,7 +31,7 @@ func bootISOImageName(infraID string) string {
 	return fmt.Sprintf("%s-%s", infraID, isoFile)
 }
 
-func createBootstrapISO(infraID, userData string) (string, error) {
+func CreateBootstrapISO(infraID, userData string) (string, error) {
 	id := uuid.New()
 	metaObj := &MetadataCloudInit{
 		UUID: id.String(),


### PR DESCRIPTION
Add nutanix platform-specific terraform variables in pkg/tfvars.

Note: This PR builds on top of #8  