### PR TITLE
Add nutanix to the bootkube configuration

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -337,6 +337,7 @@ then
 	copy_static_resources_for openstack
 	copy_static_resources_for ovirt
 	copy_static_resources_for vsphere
+	copy_static_resources_for nutanix
 
 	cp mco-bootstrap/manifests/* manifests/
 


### PR DESCRIPTION
This required for the installer to copy YAML files for static pod configurations.

Note: This PR builds on top of #10 